### PR TITLE
fix: Add default db_password to prevent Terraform input prompt

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -73,11 +73,12 @@ variable "db_name" {
 variable "db_username" {
   description = "Database username"
   type        = string
-  default     = "admin"
+  default     = "skyline_ojm"
 }
 
 variable "db_password" {
   description = "Database password"
   type        = string
   sensitive   = true
+  default     = "skyline1267"
 }


### PR DESCRIPTION
- Set db_password default value: skyline1267
- Update db_username to: skyline_ojm
- Fix GitHub Actions workflow hanging on variable input